### PR TITLE
feat: add example types to manifest

### DIFF
--- a/src/types/manifest.ts
+++ b/src/types/manifest.ts
@@ -3,10 +3,17 @@ import { emitterEventNames } from "@octokit/webhooks";
 
 export const runEvent = T.Union(emitterEventNames.map((o) => T.Literal(o)));
 
+export const exampleCommandExecutionSchema = T.Object({
+  commandInvokation: T.String({ minLength: 1 }),
+  parameters: T.Optional(T.Record(T.String(), T.Any())),
+  expectedOutput: T.String({ minLength: 1 }),
+});
+
 export const commandSchema = T.Object({
   description: T.String({ minLength: 1 }),
   "ubiquity:example": T.String({ minLength: 1 }),
   parameters: T.Optional(T.Record(T.String(), T.Any())),
+  examples: T.Optional(T.Array(exampleCommandExecutionSchema, { default: [] })),
 });
 
 export const manifestSchema = T.Object({


### PR DESCRIPTION
Resolves [#242](https://github.com/ubiquity-os/ubiquity-os-kernel/issues/242)

- Adds Example type to the manifest type