### PR TITLE
fix: update Deno Deploy metadata urls

### DIFF
--- a/src/helpers/runtime-info.ts
+++ b/src/helpers/runtime-info.ts
@@ -1,6 +1,10 @@
 import { getRuntimeKey } from "hono/adapter";
 import { getGithubContext } from "./github-context";
 
+function formatUtcTimestamp(timestamp: number): string {
+  return new Date(timestamp).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
 export abstract class PluginRuntimeInfo {
   private static _instance: PluginRuntimeInfo | null = null;
   protected _env: Record<string, unknown> = {};
@@ -80,34 +84,15 @@ export class DenoRuntimeInfo extends PluginRuntimeInfo {
     return Deno.env.get("DENO_DEPLOYMENT_ID");
   }
   public get runUrl() {
-    const projectName = Deno.env.get("DENO_PROJECT_NAME");
-    const baseUrl = `https://dash.deno.com/projects/${projectName}/logs`;
-    const start = new Date(Date.now() - 60000).toISOString();
-    const end = new Date(Date.now() + 60000).toISOString();
-    const filters = {
-      query: "",
-      timeRangeOption: "custom",
-      recentValue: "1hour",
-      customValues: {
-        start,
-        end,
-      },
-      logLevels: {
-        debug: true,
-        info: true,
-        warning: true,
-        error: true,
-      },
-      regions: {
-        "gcp-asia-southeast1": true,
-        "gcp-europe-west2": true,
-        "gcp-europe-west3": true,
-        "gcp-southamerica-east1": true,
-        "gcp-us-east4": true,
-        "gcp-us-west2": true,
-      },
-    };
-    const filtersParam = encodeURIComponent(JSON.stringify(filters));
-    return `${baseUrl}?filters=${filtersParam}`;
+    const orgSlug = Deno.env.get("DENO_DEPLOY_ORG_SLUG") || "<missing-deno-org-slug>";
+    const appSlug = Deno.env.get("DENO_DEPLOY_APP_SLUG") || "<missing-deno-app-slug>";
+    const baseUrl = `https://console.deno.com/${orgSlug}/${appSlug}/observability/logs`;
+    const searchParams = new URLSearchParams();
+
+    searchParams.set("start", formatUtcTimestamp(Date.now() - 60000));
+    searchParams.set("end", formatUtcTimestamp(Date.now() + 60000));
+    searchParams.set("tz", "Etc/UTC");
+
+    return `${baseUrl}?${searchParams.toString()}`;
   }
 }

--- a/tests/runtime-info.test.ts
+++ b/tests/runtime-info.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+type DenoEnv = {
+  get(key: string): string | undefined;
+};
+
+class TestDenoRuntimeInfo extends (jest.requireActual("../src/helpers/runtime-info") as typeof import("../src/helpers/runtime-info")).DenoRuntimeInfo {
+  public constructor() {
+    super();
+  }
+}
+
+describe("Runtime info tests", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-04-20T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    delete (globalThis as { Deno?: { env: DenoEnv } }).Deno;
+  });
+
+  it("Should build a Deno console URL with an absolute UTC window", () => {
+    (globalThis as { Deno?: { env: DenoEnv } }).Deno = {
+      env: {
+        get(key: string) {
+          switch (key) {
+            case "DENO_DEPLOY_ORG_SLUG":
+              return "ubiquity-os";
+            case "DENO_DEPLOY_APP_SLUG":
+              return "ubiquity-os-kernel-development";
+            case "DENO_DEPLOYMENT_ID":
+              return "deployment-123";
+            default:
+              return undefined;
+          }
+        },
+      },
+    };
+
+    const runtimeInfo = new TestDenoRuntimeInfo();
+
+    expect(runtimeInfo.version).toBe("deployment-123");
+    expect(runtimeInfo.runUrl).toBe(
+      "https://console.deno.com/ubiquity-os/ubiquity-os-kernel-development/observability/logs?start=2026-04-20T11%3A59%3A00Z&end=2026-04-20T12%3A01%3A00Z&tz=Etc%2FUTC"
+    );
+  });
+
+  it("Should use visible placeholders when Deno slugs are missing", () => {
+    (globalThis as { Deno?: { env: DenoEnv } }).Deno = {
+      env: {
+        get(key: string) {
+          if (key === "DENO_DEPLOYMENT_ID") {
+            return "deployment-123";
+          }
+          return undefined;
+        },
+      },
+    };
+
+    const runtimeInfo = new TestDenoRuntimeInfo();
+
+    expect(runtimeInfo.runUrl).toBe(
+      "https://console.deno.com/<missing-deno-org-slug>/<missing-deno-app-slug>/observability/logs?start=2026-04-20T11%3A59%3A00Z&end=2026-04-20T12%3A01%3A00Z&tz=Etc%2FUTC"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- switch Deno metadata links from the legacy dashboard URL to the new Deno console URL
- use absolute UTC start/end timestamps with the existing +/- 1 minute window around link generation time
- cover the Deno runtime URL builder with a focused unit test

## Testing
- bun run jest:test -- --runInBand
- bun x jest tests/runtime-info.test.ts tests/comment.test.ts --runInBand --coverage=false --reporters=default

Closes #202